### PR TITLE
Improve sorting and performance

### DIFF
--- a/cloudapp/src/app/main/main.component.ts
+++ b/cloudapp/src/app/main/main.component.ts
@@ -375,26 +375,27 @@ export class MainComponent implements OnInit {
         let comparatorResult = 0;
         switch (sort.active) {
           case 'order':
-            if (a.order && b.order) {
-              const regex: RegExp = /\b\d+\b/;
+            if (!a.order && !b.order) {
+              comparatorResult = 0;
+            } else if (!a.order) {
+              comparatorResult = -1;
+            } else if (!b.order) {
+              comparatorResult = 1;
+            } else {
+              const regex: RegExp = /\b\D*(\d+)\D*\b/;
               const matchA: RegExpMatchArray | null = a.order.match(regex);
               const matchB: RegExpMatchArray | null = b.order.match(regex);
               if (matchA && matchB) {
-                const aOrder: number = Number(matchA[0] || -1);
-                const bOrder: number = Number(matchB[0] || -1);
+                const aOrder: number = Number(matchA[1] ?? -1);
+                const bOrder: number = Number(matchB[1] ?? -1);
                 comparatorResult = aOrder - bOrder;
-              } else {
+              } else if (matchA) {
                 comparatorResult = -1;
+              } else if (matchB) {
+                comparatorResult = 1;
+              } else {
+                comparatorResult = 0;
               }
-            } else {
-              comparatorResult =
-                !a.order && !b.order
-                  ? 0
-                  : a.order && !b.order
-                  ? 1
-                  : !a.order && b.order
-                  ? -1
-                  : 0;
             }
             break;
           case 'title':

--- a/cloudapp/src/app/main/main.component.ts
+++ b/cloudapp/src/app/main/main.component.ts
@@ -192,6 +192,13 @@ export class MainComponent implements OnInit {
         switchMap((records) => {
           const upwardSystemNumbers: string[] =
             this.sruParser.getUpwardSystemNumbers(records);
+          if (upwardSystemNumbers.length == 0) {
+            this.status.set('No records found');
+            return of({
+              records,
+              upwardSystemNumbers,
+            });
+          }
           this.status.set(
             'Found ' + upwardSystemNumbers.length + ' system numbers'
           );

--- a/cloudapp/src/app/main/main.component.ts
+++ b/cloudapp/src/app/main/main.component.ts
@@ -296,23 +296,13 @@ export class MainComponent implements OnInit {
   private sortHoldings(bibInfos: BibInfo[]): BibInfo[] {
     return bibInfos.map((bibInfo) => {
       bibInfo.holdings.sort((o1, o2) => {
-        if (o1 == this.instCode) {
-          return -1;
-        }
         return o1.localeCompare(o2);
       });
-      const holdings: string[] = bibInfo.holdings;
-      return new BibInfo(
-        bibInfo.mmsId,
-        bibInfo.order,
-        bibInfo.title,
-        bibInfo.year,
-        bibInfo.edition,
-        holdings,
-        bibInfo.analytical,
-        bibInfo.additionalInfo,
-        bibInfo.duplicates
-      );
+      const index: number = bibInfo.holdings.indexOf(this.instCode);
+      if (index >= 0) {
+        bibInfo.holdings.unshift(bibInfo.holdings.splice(index, 1)[0]);
+      }
+      return bibInfo;
     });
   }
 

--- a/cloudapp/src/app/services/sru.service.ts
+++ b/cloudapp/src/app/services/sru.service.ts
@@ -2,11 +2,11 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { DestroyRef, Injectable } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CloudAppStoreService } from '@exlibris/exl-cloudapp-angular-lib';
-import { EMPTY, forkJoin, Observable, of } from 'rxjs';
+import { defer, forkJoin, merge, Observable, of, Subject } from 'rxjs';
 import {
-  expand,
-  map,
-  reduce,
+  finalize,
+  ignoreElements,
+  mergeMap,
   shareReplay,
   switchMap,
   tap,
@@ -55,35 +55,48 @@ export class SruService {
   public queryNZ(query: SruQuery): Observable<Element[]> {
     return this.getNzUrl().pipe(
       takeUntilDestroyed(this.destroyRef),
-      switchMap((url) => this.call(url, query)),
-      expand((response) => {
+      switchMap((url) => this.call(url, query, 1, 0)),
+      tap(() => {
+        this.status.set('Retrieving NZ records');
+        this.loader.setProgress(1);
+        this.loader.hasProgress(true);
+      }),
+      switchMap((response) => {
         const total: number = this.parser.getNumberOfRecords(response);
-        const next: number = this.parser.getNextRecordPosition(response);
-        if (total > 1) {
-          this.loader.hasProgress(true);
-          this.loader.setProgress(Math.round((next / total) * 100) + 1);
-          this.status.set(
-            'Calling SRU for records ' +
-              next +
-              ' to ' +
-              (next + this.MAX_RECORDS - 1) +
-              ' of ' +
-              total
+        const requests: Observable<string>[] = [];
+        for (let i = 1; i <= total; i += this.MAX_RECORDS) {
+          requests.push(
+            this.getNzUrl().pipe(switchMap((url) => this.call(url, query, i)))
           );
         }
-        if (next > 0) {
-          return this.getNzUrl().pipe(
-            switchMap((url) => this.call(url, query, next))
-          );
-        }
-        return EMPTY;
+        return this.forkJoinWithProgress(requests).pipe(
+          mergeMap(([finalResult, progress]) =>
+            merge(
+              progress.pipe(
+                tap((percent) => {
+                  this.status.set(`Retrieved ${percent}% of ${total} records`);
+                  this.loader.setProgress(percent);
+                }),
+                ignoreElements()
+              ),
+              finalResult
+            )
+          ),
+          switchMap((responses) => {
+            const result: Element[] = [];
+            this.status.set(`Parsing ${responses.length} records`);
+            responses.forEach((response) => {
+              const records: Element[] = this.parser.getRecords(response);
+              result.push(...records);
+            });
+            this.status.set(`Parsed ${responses.length} records`);
+            return of(result);
+          })
+        );
       }),
-      map((response) => {
-        const result: Element[] = this.parser.getRecords(response);
-        return result;
-      }),
-      tap(() => this.loader.hasProgress(false)),
-      reduce((accData: Element[], data: Element[]) => accData.concat(data), [])
+      tap(() => {
+        this.loader.hasProgress(false);
+      })
     );
   }
 
@@ -174,5 +187,37 @@ export class SruService {
       })
       .filter((pathParts) => pathParts.length)
       .join('/');
+  }
+
+  // See: https://angular.love/rxjs-recipes-forkjoin-with-the-progress-of-completion-for-bulk-network-requests-in-angular
+  private forkJoinWithProgress<T>(
+    arrayOfObservables: Observable<T>[]
+  ): Observable<[Observable<T[]>, Observable<number>]> {
+    return defer(() => {
+      let counter = 0;
+      const percent$ = new Subject<number>();
+
+      const modifiedObservablesList = arrayOfObservables.map((item, index) =>
+        item.pipe(
+          finalize(() => {
+            const percentValue = Math.floor(
+              (++counter * 100) / arrayOfObservables.length
+            );
+            percent$.next(percentValue);
+          })
+        )
+      );
+
+      const finalResult$ = forkJoin(modifiedObservablesList).pipe(
+        tap(() => {
+          percent$.next(100);
+          percent$.complete();
+        })
+      );
+      return of<[Observable<T[]>, Observable<number>]>([
+        finalResult$,
+        percent$.asObservable(),
+      ]);
+    });
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
-  "name": "my-exl-cloudapp",
-  "version": "1.0.0",
+  "name": "bib-hierarchy",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "my-exl-cloudapp",
-      "version": "1.0.0",
-      "license": "BSD-3-Clause",
+      "name": "bib-hierarchy",
+      "version": "2.1.0",
+      "license": "MIT",
       "dependencies": {
         "@angular/animations": "18.2.13",
         "@angular/cdk": "18.2.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bib-hierarchy",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
**Improvements:**

- Parallelise SRU calls (makes it faster 🐑💨)
- Improve sorting of the order column: Records without number are last, numbers with appended letters are treated as numbers
- Reorder holdings: the own IZ is always first for better visibility

**Fixes:**

- Getting the 'upward-hierarchy' of a record without 'upward-systemnumbers' doesn't produce a crash anymore